### PR TITLE
Update link to Robin Thompson's website

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@
 	    <h3 class="participant-name">Robin Thompson</h3>
 	    <p class="participant-affiliation"> <a href="http://evolve.zoo.ox.ac.uk/Evolve/Home.html">University
 		of Oxford</a></p>
-	    <p><a href="robin-thompson.co.uk" title="Robin Thompson">// website</a></p>
+	    <p><a href="https://robin-thompson.co.uk" title="Robin Thompson">// website</a></p>
 	    <p><a href="https://github.com/robin-thompson  "><img src="images/github-mark.png" alt="Github
 												    profile"></a>
 	      <a href="https://twitter.com/robinnthompson"><img src="images/twitter.png" alt="Twitter profile" width="35px" height="35px"></a>


### PR DESCRIPTION
Currently, the link leads to `http://hackout3.ropensci.org/robin-thompson.co.uk` which 404s due to the missing `https`. CC:// @robin-thompson